### PR TITLE
AI-powered improvements

### DIFF
--- a/spec/bidi_spec.cr
+++ b/spec/bidi_spec.cr
@@ -383,14 +383,14 @@ describe ICU::BiDi do
 
   it "should set and get reordering options" do
     bidi = ICU::BiDi.new
-    bidi.reordering_options.should eq(ICU::BiDi::ReorderingOption::Default.value) # Default options
+    bidi.reordering_options.should eq(ICU::BiDi::ReorderingOption::None.value) # Default options
 
     options = ICU::BiDi::ReorderingOption::InsertMarks | ICU::BiDi::ReorderingOption::Streaming
     bidi.reordering_options = options
     bidi.reordering_options.should eq(options.value)
 
-    bidi.reordering_options = ICU::BiDi::ReorderingOption::Default
-    bidi.reordering_options.should eq(ICU::BiDi::ReorderingOption::Default.value)
+    bidi.reordering_options = ICU::BiDi::ReorderingOption::None
+    bidi.reordering_options.should eq(ICU::BiDi::ReorderingOption::None.value)
   end
 
   it "should set context and affect paragraph level resolution" do
@@ -433,7 +433,7 @@ describe ICU::BiDi do
     ICU::BiDi::ReorderingMode::ReorderInverseForNumbersSpecial.value.should eq(6)
     ICU::BiDi::ReorderingMode::ReorderCount.value.should eq(7)
 
-    ICU::BiDi::ReorderingOption::Default.value.should eq(0)
+    ICU::BiDi::ReorderingOption::None.value.should eq(0)
     ICU::BiDi::ReorderingOption::InsertMarks.value.should eq(1)
     ICU::BiDi::ReorderingOption::RemoveControls.value.should eq(2)
     ICU::BiDi::ReorderingOption::Streaming.value.should eq(4)

--- a/spec/plural_rules_spec.cr
+++ b/spec/plural_rules_spec.cr
@@ -13,11 +13,18 @@ describe ICU::PluralRules do
     plural_rules.should be_a ICU::PluralRules
   end
 
-  it "selects the correct plural form" do
+  it "selects the correct plural form for integers" do
     plural_rules = ICU::PluralRules.new("fr")
     plural_rules.select(0).should eq "one"
     plural_rules.select(1).should eq "one"
     plural_rules.select(2).should eq "other"
+  end
+
+  it "selects the correct plural form for floats" do
+    plural_rules = ICU::PluralRules.new("fr")
+    plural_rules.select(0.0).should eq "one"
+    plural_rules.select(1.5).should eq "one"
+    plural_rules.select(2.0).should eq "other"
   end
 
   it "returns the keywords for a given locale" do

--- a/src/icu/bidi.cr
+++ b/src/icu/bidi.cr
@@ -73,8 +73,8 @@ class ICU::BiDi
   # Options for `reordering_options=`. Affects how the BiDi algorithm operates.
   @[Flags]
   enum ReorderingOption : UInt32
-    # Disable all options.
-    Default = 0 # LibICU::UBIDI_OPTION_DEFAULT
+    # No options (corresponds to ICU's UBIDI_OPTION_DEFAULT = 0).
+    None = 0
     # Insert Bidi marks (LRM or RLM) when needed to ensure correct result of a reordering to a Logical order.
     InsertMarks = 1 # LibICU::UBIDI_OPTION_INSERT_MARKS
     # Remove Bidi control characters.

--- a/src/icu/bidi.cr
+++ b/src/icu/bidi.cr
@@ -318,7 +318,6 @@ class ICU::BiDi
   # Use `write_reordered` with `WriteOption::OutputReverse` for BiDi-aware reversal.
   #
   # - `src`: The source string to reverse.
-  # - `src`: The source string to reverse.
   # - `options`: `WriteOption` flags (e.g., `DoMirroring`, `RemoveBidiControls`). Defaults to `WriteOption::None`.
   # - Returns the reversed string.
   def self.write_reverse(src : String, options : WriteOption = WriteOption::None) : String
@@ -332,7 +331,7 @@ class ICU::BiDi
 
     # If RemoveBidiControls is set, the destination size might be smaller.
     # We need to call writeReverse once with a null buffer to get the required size.
-    if (options.value.to_i & WriteOption::RemoveBidiControls.value) != 0
+    if options.includes?(WriteOption::RemoveBidiControls)
       required_size = LibICU.ubidi_write_reverse(src, src.size, Pointer(LibICU::UChar).null, 0, options.value, pointerof(ustatus))
       # U_BUFFER_OVERFLOW_ERROR is expected when passing null buffer, clear it.
       if ustatus == LibICU::UErrorCode::UBufferOverflowError

--- a/src/icu/calendar.cr
+++ b/src/icu/calendar.cr
@@ -287,20 +287,22 @@ class ICU::Calendar
     )
   end
 
-  # Checks if the calendar's current date and time fall within a weekend
-  # for its associated locale.
+  # Checks if the given date falls within a weekend for the calendar's locale.
+  #
+  # - `year`: The year (1-indexed).
+  # - `month`: The month (1-indexed).
+  # - `day`: The day of the month (1-indexed).
   def weekend?(year : Int32, month : Int32, day : Int32) : Bool
     weekend?(ICU::Date.from(year, month, day))
   end
 
-  # Checks if the calendar's current date and time fall within a weekend
-  # for its associated locale.
+  # Checks if the given date falls within a weekend for the calendar's locale.
+  #
+  # - `date`: The `Time` object representing the date to check.
   def weekend?(date : Time) : Bool
     weekend?(ICU::Date.from(date))
   end
 
-  # Checks if the calendar's current date and time fall within a weekend
-  # for its associated locale.
   private def weekend?(udate : LibICU::UDate) : Bool
     status = LibICU::UErrorCode::UZeroError
     is_weekend = LibICU.ucal_is_weekend(@ucal, udate, pointerof(status))

--- a/src/icu/calendar.cr
+++ b/src/icu/calendar.cr
@@ -253,7 +253,7 @@ class ICU::Calendar
     actual_len = LibICU.ucal_get_time_zone_id(@ucal, buff, buff.size, pointerof(status))
     ICU.check_error!(status)
 
-    buff.to_s
+    buff.to_s(actual_len)
   end
 
   # Sets the time zone associated with this calendar.

--- a/src/icu/calendar.cr
+++ b/src/icu/calendar.cr
@@ -136,7 +136,7 @@ class ICU::Calendar
   # - `field`: The `DateField` to set (e.g., `DateField::Year`, `DateField::Month`).
   # - `value`: The integer value to set for the field. Note that `DateField::Month` is 0-indexed.
   #
-  # Raises `ValueError` if the value is outside the valid range for the field.
+  # Raises `ArgumentError` if the value is outside the valid range for the field.
   def set(field : DateField, value : Int32) : Nil
     status = LibICU::UErrorCode::UZeroError
 

--- a/src/icu/calendar.cr
+++ b/src/icu/calendar.cr
@@ -357,7 +357,7 @@ class ICU::Calendar
   end
 
   def to_unsafe
-    return @ucal
+    @ucal
   end
 
   # Helper method to get the first non-zero field difference sign between
@@ -399,6 +399,6 @@ class ICU::Calendar
 
     # If we checked all fields down to seconds and the difference was always 0,
     # the times are equivalent up to the second.
-    return 0
+    0
   end
 end

--- a/src/icu/charset_detector.cr
+++ b/src/icu/charset_detector.cr
@@ -124,8 +124,7 @@ class ICU::CharsetDetector
       ustatus = LibICU::UErrorCode::UZeroError
       uenum = LibICU.ucsdet_get_all_detectable_charsets(@csdet, pointerof(ustatus))
       ICU.check_error!(ustatus)
-      @@detectable_charsets = UEnum.new(uenum).to_a
-      LibICU.uenum_close(uenum)
+      @@detectable_charsets = UEnum.new(uenum, owns: true).to_a
     end
     @@detectable_charsets.not_nil!
   end

--- a/src/icu/collator.cr
+++ b/src/icu/collator.cr
@@ -38,9 +38,7 @@ class ICU::Collator
     ustatus = LibICU::UErrorCode::UZeroError
     uenum = LibICU.ucol_open_available_locales(pointerof(ustatus))
     ICU.check_error!(ustatus)
-    locales = UEnum.new(uenum).to_a
-    LibICU.uenum_close(uenum)
-    Set(String).new(locales)
+    Set(String).new(UEnum.new(uenum, owns: true).to_a)
   end
 
   KEYWORDS = begin
@@ -48,13 +46,12 @@ class ICU::Collator
     ustatus = LibICU::UErrorCode::UZeroError
     kenum = LibICU.ucol_get_keywords(pointerof(ustatus))
     ICU.check_error!(ustatus)
-    UEnum.new(kenum).each do |keyword|
+    UEnum.new(kenum, owns: true).each do |keyword|
       ustatus = LibICU::UErrorCode::UZeroError
       venum = LibICU.ucol_get_keyword_values(keyword, pointerof(ustatus))
       ICU.check_error!(ustatus)
-      keywords[keyword] = Set(String).new(UEnum.new(venum).to_a)
+      keywords[keyword] = Set(String).new(UEnum.new(venum, owns: true).to_a)
     end
-    LibICU.uenum_close(kenum)
     keywords
   end
 

--- a/src/icu/datetime_formatter.cr
+++ b/src/icu/datetime_formatter.cr
@@ -84,6 +84,8 @@ class ICU::DateTimeFormatter
       pointerof(ustatus)
     )
 
+    @ucal = nil
+
     ICU.check_error!(ustatus)
   end
 

--- a/src/icu/locale.cr
+++ b/src/icu/locale.cr
@@ -256,8 +256,7 @@ class ICU::Locale
     ustatus = LibICU::UErrorCode::UZeroError
     uenum = LibICU.uloc_open_keywords(@id, pointerof(ustatus))
     ICU.check_error!(ustatus)
-    # Use the correct class name ICU::UEnum
-    ICU::UEnum.new(uenum)
+    ICU::UEnum.new(uenum, owns: true)
   end
 
   # Converts the locale ID to a BCP 47 language tag.
@@ -398,9 +397,7 @@ class ICU::Locale
     ustatus = LibICU::UErrorCode::UZeroError
     uenum = LibICU.uloc_open_available_by_type(LibICU::ULocAvailableType::AvailableDefault, pointerof(ustatus))
     ICU.check_error!(ustatus)
-    # Use the correct class name ICU::UEnum
-    locales = UEnum.new(uenum).to_a
-    LibICU.uenum_close(uenum)
+    locales = UEnum.new(uenum, owns: true).to_a
     locales.map { |r| new(r) }
   end
 

--- a/src/icu/normalizer.cr
+++ b/src/icu/normalizer.cr
@@ -57,10 +57,9 @@ class ICU::Normalizer
   # ICU::Normalizer::NFC.new.normalize(str).bytes # => [195, 128]
   # ```
   def normalize(text : String) : String
-    # allocate twice the size of the source string to be sure
+    # Allocate twice the size of the source string as a conservative estimate.
     src = text.to_uchars
     dest = ICU::UChars.new(text.size * 2)
-    size = limit = text.size
 
     ustatus = LibICU::UErrorCode::UZeroError
     size = LibICU.unorm2_normalize(@unorm, src, text.size, dest, dest.size, pointerof(ustatus))

--- a/src/icu/number_formatter.cr
+++ b/src/icu/number_formatter.cr
@@ -41,17 +41,15 @@ class ICU::NumberFormatter
   end
 
   # Formats a number into a string.
-
+  #
   # ```
   # nf = ICU::NumberFormatter.new("en_US")
   # nf.format(1234.56) # => "1,234.56"
   # ```
   def format(number : Float64) : String
-    ustatus = LibICU::UErrorCode::UZeroError
-    buff = UChars.new(32)
-    len = LibICU.unum_format_double(@unum, number, buff, buff.size, nil, pointerof(ustatus))
-    ICU.check_error!(ustatus)
-    buff.to_s(len)
+    ICU.with_auto_resizing_buffer(32, UChars) do |buff, status_ptr|
+      LibICU.unum_format_double(@unum, number, buff.as(UChars), buff.size, nil, status_ptr)
+    end
   end
 
   # Formats a number with a currency code (3 letters code, see ISO 4217) into a string.
@@ -61,12 +59,10 @@ class ICU::NumberFormatter
   # nf.format(1234.56, "USD") # => "$1,234.56"
   # ```
   def format(number : Float64, currency_code : String) : String
-    ustatus = LibICU::UErrorCode::UZeroError
     currency_code = currency_code.to_uchars
-    buff = UChars.new(32)
-    len = LibICU.unum_format_double_currency(@unum, number, currency_code, buff, buff.size, nil, pointerof(ustatus))
-    ICU.check_error!(ustatus)
-    buff.to_s(len)
+    ICU.with_auto_resizing_buffer(32, UChars) do |buff, status_ptr|
+      LibICU.unum_format_double_currency(@unum, number, currency_code, buff.as(UChars), buff.size, nil, status_ptr)
+    end
   end
 
   # Formats a number into a string.
@@ -76,11 +72,9 @@ class ICU::NumberFormatter
   # nf.format(1234) # => "1,234"
   # ```
   def format(number : Int64) : String
-    ustatus = LibICU::UErrorCode::UZeroError
-    buff = UChars.new(32)
-    len = LibICU.unum_format_int64(@unum, number, buff, buff.size, nil, pointerof(ustatus))
-    ICU.check_error!(ustatus)
-    buff.to_s(len)
+    ICU.with_auto_resizing_buffer(32, UChars) do |buff, status_ptr|
+      LibICU.unum_format_int64(@unum, number, buff.as(UChars), buff.size, nil, status_ptr)
+    end
   end
 
   # Parses a string into an integer number.

--- a/src/icu/plural_rules.cr
+++ b/src/icu/plural_rules.cr
@@ -49,14 +49,21 @@ class ICU::PluralRules
   #
   # ```
   # plural_rules = ICU::PluralRules.new("fr")
-  # plural_rules.select(1) # => "one"
+  # plural_rules.select(1)   # => "one"
+  # plural_rules.select(1.5) # => "one"
+  # plural_rules.select(2)   # => "other"
   # ```
   def select(number : Float64) : String
-    ustatus = LibICU::UErrorCode::UZeroError
-    buff = UChars.new(32)
-    len = LibICU.uplrules_select(@uplrules, number, buff, buff.size, pointerof(ustatus))
-    ICU.check_error!(ustatus)
-    buff.to_s(len)
+    ICU.with_auto_resizing_buffer(32, UChars) do |buff, status_ptr|
+      LibICU.uplrules_select(@uplrules, number, buff.as(UChars), buff.size, status_ptr)
+    end
+  end
+
+  # Selects the plural form for the given integer number.
+  #
+  # Delegates to `#select(Float64)` after converting the integer.
+  def select(number : Int) : String
+    self.select(number.to_f64)
   end
 
   # Returns keywords associated to this plural rules.

--- a/src/icu/plural_rules.cr
+++ b/src/icu/plural_rules.cr
@@ -69,6 +69,6 @@ class ICU::PluralRules
     ustatus = LibICU::UErrorCode::UZeroError
     keywords = LibICU.uplrules_get_keywords(@uplrules, pointerof(ustatus))
     ICU.check_error!(ustatus)
-    ICU::UEnum.new(keywords).to_a
+    ICU::UEnum.new(keywords, owns: true).to_a
   end
 end

--- a/src/icu/region.cr
+++ b/src/icu/region.cr
@@ -62,8 +62,7 @@
       ustatus = LibICU::UErrorCode::UZeroError
       uenum = LibICU.uregion_get_contained_regions(@uregion, pointerof(ustatus))
       ICU.check_error!(ustatus)
-      regions = UEnum.new(uenum).to_a
-      LibICU.uenum_close(uenum)
+      regions = UEnum.new(uenum, owns: true).to_a
       regions.map { |r| self.class.new(r) }
     end
   end

--- a/src/icu/uenum.cr
+++ b/src/icu/uenum.cr
@@ -5,10 +5,13 @@
 class ICU::UEnum
   include Enumerable(String)
 
-  @free = true
-
-  def initialize(@uenum : LibICU::UEnumeration)
-    @free = false
+  # Wraps an existing `UEnumeration` handle.
+  #
+  # Pass `owns: true` to transfer ownership so that the handle is closed when
+  # this object is finalized. The default (`owns: false`) leaves lifetime
+  # management to the caller.
+  def initialize(@uenum : LibICU::UEnumeration, *, owns : Bool = false)
+    @free = owns
   end
 
   # FIXME: not thread-safe
@@ -16,6 +19,7 @@ class ICU::UEnum
     ustatus = LibICU::UErrorCode::UZeroError
     @uenum = LibICU.uenum_open_char_strings_enumeration(elements.map(&.to_unsafe), elements.size, pointerof(ustatus))
     ICU.check_error!(ustatus)
+    @free = true
   end
 
   def finalize


### PR DESCRIPTION
Summary Table

| # | File | Severity | Issue |
|---|------|----------|-------|
| 1 | `uenum.cr` | Medium | Ownership logic inverted/fragile |
| 2 | `calendar.cr:256` | Bug | `buff.to_s` ignores `actual_len` |
| 3 | `calendar.cr:140` | Low | Validation overhead with wrong docs (says `ValueError`) |
| 4 | `calendar.cr:280` | Low | Wrong doc comments on `weekend?` overloads |
| 5 | `calendar.cr:400` | Style | Explicit `return 0` unnecessary |
| 6 | `calendar.cr:357` | Style | Explicit `return` unnecessary |
| 7 | `bidi.cr:321` | Style | Duplicate doc line |
| 8 | `bidi.cr:334` | Style | Use `options.includes?` instead of bitwise AND |
| 9 | `number_formatter.cr:50` | Medium | No buffer overflow protection on `format` |
| 10 | `locale.cr:222` | Low | Dead `initial_buff_size` variable |
| 11 | `locale.cr:397` | Low | Fragile manual `uenum` close pattern |
| 12 | `normalizer.cr:63` | Low | Unused `limit` variable |
| 13 | `datetime_formatter.cr:70` | Style | Inconsistent `@ucal` initialization |
| 14 | `plural_rules.cr` | Low | No `Int` overload for `select` |
| 15 | `bidi.cr:77` | Style | `Default = 0` in `@[Flags]` enum should be `None