### PR TITLE
Add ICU::USet and extend Collator/Transliterator with Set(Char) APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ __Internals__
 - [x] [UChars](https://olbat.github.io/icu.cr/ICU/UChars.html), UChar conversion routines
 - [x] [UEnum](https://olbat.github.io/icu.cr/ICU/UEnum.html), String Enumeration _(uenum.h)_
 - [ ] `ustring`, Strings and Character Iteration _(ustring.h, uiter.h)_
+- [x] [USet](https://olbat.github.io/icu.cr/ICU/USet.html), Sets of Unicode Code Points and Strings _(uset.h)_
 - [ ] `utext`, Abstract Unicode Text API _(utext.h)_
-- [ ] `uset`, Sets of Unicode Code Points and Strings _(uset.h)_
 - [ ] `ures`, Resource Bundles _(ures.h)_
 - [ ] `usprep`, StringPrep _(usprep.h)_
 - [ ] `uspoof`, Identifier Spoofing & Confusability _(uspoof.h)_

--- a/spec/collator_spec.cr
+++ b/spec/collator_spec.cr
@@ -161,4 +161,48 @@ describe "ICU::Collator" do
       col.reorder_codes.should eq(rc)
     end
   end
+
+  describe "tailored_set" do
+    it "returns a Set(Char) containing the re-ordered character" do
+      # "&b < a" moves 'a' to sort after 'b'; only 'a' is tailored
+      col = ICU::Collator.new(rules: "&b < a")
+      ts = col.tailored_set
+      ts.should be_a(Set(Char))
+      ts.includes?('a').should be_true
+    end
+
+    it "returns a non-nil Set(Char) for the default collator" do
+      ICU::Collator.new.tailored_set.should be_a(Set(Char))
+    end
+  end
+
+  describe "contractions" do
+    it "returns a Set(Char)" do
+      ICU::Collator.new("cs").contractions.should be_a(Set(Char))
+    end
+
+    it "returns a Set(Char) for the default collator" do
+      ICU::Collator.new.contractions.should be_a(Set(Char))
+    end
+  end
+
+  describe "contractions_and_expansions" do
+    it "returns a tuple of two Set(Char) values" do
+      conts, exps = ICU::Collator.new("cs").contractions_and_expansions
+      conts.should be_a(Set(Char))
+      exps.should be_a(Set(Char))
+    end
+
+    it "returns a non-empty expansions set for Czech" do
+      # Czech has expansion mappings (characters mapping to multiple collation elements)
+      _, exps = ICU::Collator.new("cs").contractions_and_expansions
+      exps.should_not be_empty
+    end
+
+    it "accepts add_prefixes: true" do
+      conts, exps = ICU::Collator.new("cs").contractions_and_expansions(add_prefixes: true)
+      conts.should be_a(Set(Char))
+      exps.should be_a(Set(Char))
+    end
+  end
 end

--- a/spec/transliterator_spec.cr
+++ b/spec/transliterator_spec.cr
@@ -106,4 +106,21 @@ describe "ICU::Transliterator" do
       trans.reverse!.transliterate("tí phḗis").should eq("τί φῄς")
     end
   end
+
+  describe "source_set" do
+    it "returns a Set(Char)" do
+      ICU::Transliterator.new("Latin-ASCII").source_set.should be_a(Set(Char))
+    end
+
+    it "contains characters that the transliterator modifies" do
+      # Latin-ASCII operates on combining diacritical marks (U+0300 = combining grave accent)
+      src = ICU::Transliterator.new("Latin-ASCII").source_set
+      src.includes?('\u0300').should be_true
+    end
+
+    it "does not contain plain ASCII letters (they pass through unchanged)" do
+      src = ICU::Transliterator.new("Latin-ASCII").source_set
+      src.includes?('a').should be_false
+    end
+  end
 end


### PR DESCRIPTION
- Add ICU::USet wrapper (uset.h): Enumerable(Char) over Unicode character sets, with set operations (add, remove, union, intersection, complement) and conversion to Crystal Set(Char)
- Extend ICU::Collator with tailored_set, contractions, and contractions_and_expansions returning Set(Char)
- Extend ICU::Transliterator with source_set returning Set(Char)
- Update README to mark uset as done and note unwrapped internal APIs